### PR TITLE
Fix code scanning alert no. 403: 'requireSSL' attribute is not set to true

### DIFF
--- a/XCODE/SecretlyInLove/MonoBleedingEdge/etc/mono/4.0/web.config
+++ b/XCODE/SecretlyInLove/MonoBleedingEdge/etc/mono/4.0/web.config
@@ -110,7 +110,7 @@
 		  <add name="ScriptModule-4.0" type="System.Web.Handlers.ScriptModule, System.Web.Extensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
 		</httpModules>
 		<authentication mode="Forms">
-			<forms name=".MONOAUTH" loginUrl="login.aspx" protection="All" timeout="30" path="/">
+			<forms name=".MONOAUTH" loginUrl="login.aspx" protection="All" timeout="30" path="/" requireSSL="true">
 				<credentials passwordFormat="Clear">					
 				</credentials>
 			</forms>


### PR DESCRIPTION
Fixes [https://github.com/SecretlyInLove/SecretlyInLove/security/code-scanning/403](https://github.com/SecretlyInLove/SecretlyInLove/security/code-scanning/403)

To fix the problem, we need to set the `requireSSL` attribute to `true` in the `<forms>` element within the `web.config` file. This change ensures that forms authentication cookies are only sent over HTTPS, thereby protecting sensitive data from being intercepted over an insecure connection.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
