### PR TITLE
Fix code scanning alert no. 404: 'requireSSL' attribute is not set to true

### DIFF
--- a/XCODE/SecretlyInLove/MonoBleedingEdge/etc/mono/4.5/web.config
+++ b/XCODE/SecretlyInLove/MonoBleedingEdge/etc/mono/4.5/web.config
@@ -110,11 +110,13 @@
 		  <add name="ScriptModule-4.0" type="System.Web.Handlers.ScriptModule, System.Web.Extensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"/>
 		</httpModules>
 		<authentication mode="Forms">
-			<forms name=".MONOAUTH" loginUrl="login.aspx" protection="All" timeout="30" path="/">
+			<forms name=".MONOAUTH" loginUrl="login.aspx" protection="All" timeout="30" path="/" requireSSL="true">
 				<credentials passwordFormat="Clear">					
 				</credentials>
 			</forms>
 		</authentication>
+		</authentication>
+		<httpCookies requireSSL="true" />
 		<machineKey validationKey="AutoGenerate" decryptionKey="AutoGenerate" validation="SHA1" />
 		<globalization  requestEncoding="utf-8"
 				responseEncoding="utf-8"


### PR DESCRIPTION
Fixes [https://github.com/SecretlyInLove/SecretlyInLove/security/code-scanning/404](https://github.com/SecretlyInLove/SecretlyInLove/security/code-scanning/404)

To fix the problem, we need to ensure that the `requireSSL` attribute is set to `true` in both the `<forms>` and `<httpCookies>` elements within the `web.config` file. This will enforce the use of SSL for web forms and cookies, thereby protecting sensitive data during transmission.

1. Locate the `<forms>` element within the `<authentication>` section and add the attribute `requireSSL="true"`.
2. Add the `<httpCookies>` element within the `<system.web>` section and set the attribute `requireSSL="true"`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
